### PR TITLE
Add clarifying sentence for the `Orientation` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ nifti.zattrs["VoxelSize"][4]   ==  zattrs["multiscales"][0]["coordinateTransform
 
 As a reminder, the nifti1 header has the following structure:
 
-| Type       | Name             | NIfTI-1 usage                       | JNIfTI                | JSON type                              |
+| Type       | Name             | NIFfI-1 usage                       | JNIfTI                | JSON type                              |
 | ---------- | ---------------- | ----------------------------------- | --------------------- | -------------------------------------- |
 | `int`      | `sizeof_hdr`     | __MUST__ be 348                     | `"NIIHeaderSize"`     | `integer`                              |
 | `char`     | `data_type`      | ~~UNUSED~~                          | `"A75DataTypeName"`   | `string`                               |

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ nifti.zattrs["VoxelSize"][4]   ==  zattrs["multiscales"][0]["coordinateTransform
 
 As a reminder, the nifti1 header has the following structure:
 
-| Type       | Name             | NIFfI-1 usage                       | JNIfTI                | JSON type                              |
+| Type       | Name             | NIfTI-1 usage                       | JNIfTI                | JSON type                              |
 | ---------- | ---------------- | ----------------------------------- | --------------------- | -------------------------------------- |
 | `int`      | `sizeof_hdr`     | __MUST__ be 348                     | `"NIIHeaderSize"`     | `integer`                              |
 | `char`     | `data_type`      | ~~UNUSED~~                          | `"A75DataTypeName"`   | `string`                               |

--- a/nifti-zarr-schema-1.0.rc1.json
+++ b/nifti-zarr-schema-1.0.rc1.json
@@ -156,7 +156,7 @@
       "maxItems": 5
     },
     "Orientation": {
-      "description": "Handedness of the coordinate system to indicate the direction of the positive axis. For example, if the positive x-axis is in the direction from left to right, then 'x': 'r' ",
+      "description": "Handedness of the coordinate system to denote the positive direction along an axis. For example, if the positive x-axis is in the direction from left to right, then 'x': 'r' ",
       "type": "object",
       "properties": {
         "x": {

--- a/nifti-zarr-schema-1.0.rc1.json
+++ b/nifti-zarr-schema-1.0.rc1.json
@@ -156,7 +156,7 @@
       "maxItems": 5
     },
     "Orientation": {
-      "description": "Handedness of the coordinate system",
+      "description": "Handedness of the coordinate system to indicate the direction of the positive axis. For example, if the positive x-axis is in the direction from left to right, then 'x': 'r' ",
       "type": "object",
       "properties": {
         "x": {


### PR DESCRIPTION
Just adding a clarifying sentence based on the [JNIfTI docs](https://github.com/NeuroJSON/jnifti/blob/master/JNIfTI_specification.md#orientation-nifti-1-header-pixdim0).  Some tools refer to the RAS orientation as LPI (e.g. ITK-SNAP).  The [Nibabel docs](https://nipy.org/nibabel/coordinate_systems.html#naming-reference-spaces) also make note of this discrepancy between tools.

cc @balbasty @calvinchai 